### PR TITLE
Recreate mesh if canvas size changed

### DIFF
--- a/src/HTMLMesh.js
+++ b/src/HTMLMesh.js
@@ -59,6 +59,7 @@ class HTMLTexture extends CanvasTexture {
 	constructor( dom ) {
 
 		super( html2canvas( dom ) );
+		this.prevCanvasSize = { width: this.image.width, height: this.image.height };
 
 		this.dom = dom;
 
@@ -102,6 +103,12 @@ class HTMLTexture extends CanvasTexture {
 		this.needsUpdate = true;
 
 		this.scheduleUpdate = null;
+
+		if ( this.image.width !== this.prevCanvasSize.width || this.image.height !== this.prevCanvasSize.height ) {
+			this.prevCanvasSize.width = this.image.width;
+			this.prevCanvasSize.height = this.image.height;
+			this.dom.dispatchEvent(new CustomEvent('size-changed'))
+		}
 
 	}
 
@@ -480,11 +487,12 @@ function html2canvas( element ) {
 	if ( canvas === undefined ) {
 
 		canvas = document.createElement( 'canvas' );
-		canvas.width = offset.width;
-		canvas.height = offset.height;
 		canvases.set( element, canvas );
 
 	}
+
+	canvas.width = offset.width;
+	canvas.height = offset.height;
 
 	const context = canvas.getContext( '2d'/*, { alpha: false }*/ );
 

--- a/src/aframe-html.js
+++ b/src/aframe-html.js
@@ -38,6 +38,10 @@ AFRAME.registerComponent('html', {
 				intersection: null
 			}
 		};
+		this.sizeChanged = this.sizeChanged.bind(this);
+	},
+	sizeChanged() {
+		this.update();
 	},
 	play() {
 		this.el.addEventListener('click', this.onClick);
@@ -45,6 +49,7 @@ AFRAME.registerComponent('html', {
 		this.el.addEventListener('mouseenter', this.onMouseEnter);
 		this.el.addEventListener('mouseup', this.onMouseUp);
 		this.el.addEventListener('mousedown', this.onMouseDown);
+		this.data.html.addEventListener('size-changed', this.sizeChanged)
 	},
 	pause() {
 		this.el.removeEventListener('click', this.onClick);
@@ -52,6 +57,7 @@ AFRAME.registerComponent('html', {
 		this.el.removeEventListener('mouseenter', this.onMouseEnter);
 		this.el.removeEventListener('mouseup', this.onMouseUp);
 		this.el.removeEventListener('mousedown', this.onMouseDown);
+		this.data.html.removeEventListener('size-changed', this.sizeChanged)
 	},
 	update() {
 		this.remove();


### PR DESCRIPTION
I have a specific use case of a wrist UI that change based on the context. If I'm close to a car I can change the colors of the car for example.
For this to work I need to recreate the mesh. I tried at first to recreate only the geometry but couldn't make it work, it was indeed bigger but still the old render and I didn't figure why, so I recreate the mesh completely. I'm happy with it.
There is also a PR about that issue but it was not correct https://github.com/mrdoob/three.js/pull/23662

![Capture d’écran du 2023-04-20 12-27-31](https://user-images.githubusercontent.com/112249/233340305-d766da91-a8de-4dd5-ba98-93dee60d9813.png)

![Capture d’écran du 2023-04-20 12-27-14](https://user-images.githubusercontent.com/112249/233340325-7cde989d-1604-48e0-80e2-5b2b2c297cff.png)
