### PR TITLE
Add image support (fix #13)

### DIFF
--- a/src/HTMLMesh.js
+++ b/src/HTMLMesh.js
@@ -277,6 +277,19 @@ function html2canvas( element ) {
 			context.drawImage( element, 0, 0 );
 			context.restore();
 
+		} else if ( element instanceof HTMLImageElement ) {
+
+			if ( element.style.display === 'none' ) return;
+
+			const rect = element.getBoundingClientRect();
+
+			x = rect.left - offset.left - 0.5;
+			y = rect.top - offset.top - 0.5;
+			width = rect.width + 0.5;
+			height = rect.height + 0.5;
+
+			context.drawImage( element, x, y, width, height );
+
 		} else {
 
 			if ( element.style.display === 'none' ) return;

--- a/src/HTMLMesh.js
+++ b/src/HTMLMesh.js
@@ -285,8 +285,8 @@ function html2canvas( element ) {
 
 			x = rect.left - offset.left - 0.5;
 			y = rect.top - offset.top - 0.5;
-			width = rect.width + 0.5;
-			height = rect.height + 0.5;
+			width = rect.width;
+			height = rect.height;
 
 			context.drawImage( element, x, y, width, height );
 


### PR DESCRIPTION
This closes #13.

Backport of the changes in r152 that was merged https://github.com/mrdoob/three.js/pull/25916
I didn't backport the change 
`this.encoding = sRGBEncoding -> this.colorSpace = SRGBColorSpace`
this one will be for aframe 1.5.0.