### PR TITLE
Draw canvas elements in their proper position

### DIFF
--- a/src/HTMLMesh.js
+++ b/src/HTMLMesh.js
@@ -271,10 +271,15 @@ function html2canvas( element ) {
 			// Canvas element
 			if ( element.style.display === 'none' ) return;
 
-			context.save();
+			const rect = element.getBoundingClientRect();
+
+			x = rect.left - offset.left - 0.5;
+			y = rect.top - offset.top - 0.5;
+
+		        context.save();
 			const dpr = window.devicePixelRatio;
 			context.scale( 1 / dpr, 1 / dpr );
-			context.drawImage( element, 0, 0 );
+			context.drawImage( element, x, y );
 			context.restore();
 
 		} else if ( element instanceof HTMLImageElement ) {


### PR DESCRIPTION
Dear author,

first of all, thanks for the excellent resources you provide to the WebXR community.

This change introduces that, same as for other element types, a canvas element is drawn in the result canvas starting from its computed position in the DOM instead of (0,0)

Attached are screenshots from the behavior before (canvas overlapping with the other UI elements) and after (canvas rendered under the buttons as expected).

Please let me know if I am overlooking something.

All the best

Antonio

![before](https://github.com/AdaRoseCannon/aframe-htmlmesh/assets/3331940/da6fa9ac-4c50-420a-b4be-e1897c4fc499)
![after](https://github.com/AdaRoseCannon/aframe-htmlmesh/assets/3331940/a94c2b99-f5ea-4fcf-87f2-b18826fe412f)
