### PR TITLE
When an element is transparent, clear it

### DIFF
--- a/src/HTMLMesh.js
+++ b/src/HTMLMesh.js
@@ -505,6 +505,8 @@ function html2canvas( element ) {
 
 	// console.time( 'drawElement' );
 
+	context.clearRect(0, 0, canvas.width, canvas.height);
+
 	drawElement( element );
 
 	// console.timeEnd( 'drawElement' );


### PR DESCRIPTION
Dear author,

currently it is the case that for transparent elements, we skip the filling of the background. However, filling the background has also the important side effect of clearing the canvas e.g. when elements in the foreground change size.

An example is a button that changes size upon clicking because the text it contains is smaller. Clicking on the button would leave a "ghost" behind when the container element is transparent.

This change makes it so that when an element has a transparent background, we do the equivalent of filling with transparent, that is, clear the area in the canvas.

I attach two examples of the behavior before (the resized button leaves a ghost behind) and after (the button is completely redrawn, as the background is cleared.

All the best

Antonio
![before](https://github.com/AdaRoseCannon/aframe-htmlmesh/assets/3331940/976e162b-7fe0-41b1-b7a0-27dec1d559e9)
![after](https://github.com/AdaRoseCannon/aframe-htmlmesh/assets/3331940/977a2c4e-77b6-4849-ba40-1e71266692c8)
