### PR TITLE
Remove rollup-plugin-replace-imports-with-vars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,64 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "21.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.2.tgz",
@@ -172,9 +230,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -625,15 +683,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -710,14 +759,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-      "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
+      "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.5.0",
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
         "source-map-support": "~0.5.20"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@rollup/plugin-strip": "^2.1.0",
         "rollup": "^2.67.2",
-        "rollup-plugin-replace-imports-with-vars": "^1.0.2",
         "rollup-plugin-terser": "^7.0.2",
         "tablemark": "^3.0.0"
       }
@@ -301,50 +300,6 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
-    "node_modules/find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-      "dev": true,
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-      }
-    },
-    "node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -385,12 +340,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -497,27 +446,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -534,21 +462,6 @@
       "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -594,51 +507,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -664,18 +532,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/randombytes": {
@@ -714,19 +570,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-replace-imports-with-vars": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-replace-imports-with-vars/-/rollup-plugin-replace-imports-with-vars-1.0.2.tgz",
-      "integrity": "sha512-sRCMPHxxSOdDqTO2JqC7+1pgbx9ostG+klq/xYQch29csDnDecv4+AL8lTt2clKAsOlpJCqHRx+WHcIfTePEjQ==",
-      "dev": true,
-      "dependencies": {
-        "rollup-plugin-typescript2": "^0.29.0",
-        "typescript": "^4.0.5"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
     "node_modules/rollup-plugin-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -741,29 +584,6 @@
       "peerDependencies": {
         "rollup": "^2.0.0"
       }
-    },
-    "node_modules/rollup-plugin-typescript2": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.29.0.tgz",
-      "integrity": "sha512-YytahBSZCIjn/elFugEGQR5qTsVhxhUwGZIsA9TmrSsC88qroGo65O5HZP/TTArH2dm0vUmYWhKchhwi2wL9bw==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "find-cache-dir": "^3.3.1",
-        "fs-extra": "8.1.0",
-        "resolve": "1.17.0",
-        "tslib": "2.0.1"
-      },
-      "peerDependencies": {
-        "rollup": ">=1.26.3",
-        "typescript": ">=2.4.0"
-      }
-    },
-    "node_modules/rollup-plugin-typescript2/node_modules/tslib": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
-      "dev": true
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -784,15 +604,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
     },
     "node_modules/sentence-case": {
       "version": "3.0.4",
@@ -926,28 +737,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
-    },
-    "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/upper-case-first": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/plugin-strip": "^2.1.0",
     "rollup": "^2.67.2",
-    "rollup-plugin-replace-imports-with-vars": "^1.0.2",
     "rollup-plugin-terser": "^7.0.2",
     "tablemark": "^3.0.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,6 @@
 /* jshint esversion:11 */
 import { terser } from "rollup-plugin-terser";
 import strip from '@rollup/plugin-strip';
-import replace from 'rollup-plugin-replace-imports-with-vars';
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 // import {copyFileSync} from 'fs';


### PR DESCRIPTION
Dear maintainers,

when running npm install on latest codebase one currently sees this:

<pre><span style="color:#26A269"><b>antonio@wonderland</b></span>:<span style="color:#12488B"><b>~/aframe-htmlmesh</b></span>$ npm install

up to date, audited 91 packages in 912ms

11 packages are looking for funding
  run `npm fund` for details

<span style="color:#C01C28"><b>2</b></span> vulnerabilities (1 <span style="color:#A2734C"><b>moderate</b></span>, 1 <span style="color:#C01C28"><b>high</b></span>)

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
</pre>

Later, when running npm run build, this message shows up:

<pre><span style="color:#26A269"><b>user@machine</b></span>:<span style="color:#12488B"><b>~/aframe-htmlmesh</b></span>$ npm run build

&gt; aframe-htmlmesh@2.1.0 build
&gt; rollup -c &amp;&amp; find build -maxdepth 2 -iname &quot;*.js&quot; -not -type d -exec du -h {} \;;npm run docs

<b>loaded rollup.config.js with warnings</b>
<span style="color:#A2734C"><b>(!) Unused external imports</b></span>
default imported from external module &quot;rollup-plugin-replace-imports-with-vars&quot; but never used in &quot;rollup.config.js&quot;

<span style="color:#2AA1B3"><b>src/aframe-html.js</b></span><span style="color:#2AA1B3"> → </span><span style="color:#2AA1B3"><b>build/aframe-html.js</b></span><span style="color:#2AA1B3">...</span>
<span style="color:#26A269">created </span><span style="color:#26A269"><b>build/aframe-html.js</b></span><span style="color:#26A269"> in </span><span style="color:#26A269"><b>106ms</b></span>

<span style="color:#2AA1B3"><b>src/aframe-html.js</b></span><span style="color:#2AA1B3"> → </span><span style="color:#2AA1B3"><b>build/aframe-html.min.js</b></span><span style="color:#2AA1B3">...</span>
<span style="color:#26A269">created </span><span style="color:#26A269"><b>build/aframe-html.min.js</b></span><span style="color:#26A269"> in </span><span style="color:#26A269"><b>445ms</b></span>
12K	build/aframe-html.min.js
20K	build/aframe-html.js

&gt; aframe-htmlmesh@2.1.0 docs
&gt; awk &apos;
&gt;  BEGIN {p=1}
&gt;  /^&lt;!--DOCS--&gt;/ {print;system(&quot;node ./aframe-to-md.mjs ./build/aframe-html.js&quot;);p=0}
&gt;  /^&lt;!--DOCS_END--&gt;/ {p=1}
&gt;  p&apos; README.md &gt; ~README.md &amp;&amp; mv ~README.md README.md
</pre>

This PR addresses the two complaints by:

1. Removing the unused dependency "rollup-plugin-replace-imports-with-vars"
2. running "npm audit fix" so that better dependencies are chosen for the package

After the change, the build is clean and the number of reported vulnerabilities is 0

<pre><span style="color:#26A269"><b>user@machine</b></span>:<span style="color:#12488B"><b>~/aframe-htmlmesh</b></span>$ npm install

up to date, audited 78 packages in 875ms

8 packages are looking for funding
  run `npm fund` for details

found <span style="color:#26A269"><b>0</b></span> vulnerabilities
</pre>

<pre><span style="color:#26A269"><b>antonio@wonderland</b></span>:<span style="color:#12488B"><b>~/aframe-htmlmesh</b></span>$ npm run build

&gt; aframe-htmlmesh@2.1.0 build
&gt; rollup -c &amp;&amp; find build -maxdepth 2 -iname &quot;*.js&quot; -not -type d -exec du -h {} \;;npm run docs


<span style="color:#2AA1B3"><b>src/aframe-html.js</b></span><span style="color:#2AA1B3"> → </span><span style="color:#2AA1B3"><b>build/aframe-html.js</b></span><span style="color:#2AA1B3">...</span>
<span style="color:#26A269">created </span><span style="color:#26A269"><b>build/aframe-html.js</b></span><span style="color:#26A269"> in </span><span style="color:#26A269"><b>119ms</b></span>

<span style="color:#2AA1B3"><b>src/aframe-html.js</b></span><span style="color:#2AA1B3"> → </span><span style="color:#2AA1B3"><b>build/aframe-html.min.js</b></span><span style="color:#2AA1B3">...</span>
<span style="color:#26A269">created </span><span style="color:#26A269"><b>build/aframe-html.min.js</b></span><span style="color:#26A269"> in </span><span style="color:#26A269"><b>480ms</b></span>
12K	build/aframe-html.min.js
20K	build/aframe-html.js

&gt; aframe-htmlmesh@2.1.0 docs
&gt; awk &apos;
&gt;  BEGIN {p=1}
&gt;  /^&lt;!--DOCS--&gt;/ {print;system(&quot;node ./aframe-to-md.mjs ./build/aframe-html.js&quot;);p=0}
&gt;  /^&lt;!--DOCS_END--&gt;/ {p=1}
&gt;  p&apos; README.md &gt; ~README.md &amp;&amp; mv ~README.md README.md
</pre>

All the best

Antonio