### PR TITLE
HTMLMesh: do not render the script tag

### DIFF
--- a/src/HTMLMesh.js
+++ b/src/HTMLMesh.js
@@ -247,6 +247,13 @@ function html2canvas( element ) {
 
 	function drawElement( element, style ) {
 
+		// Do not render invisible elements, comments and scripts.
+		if ( element.nodeType === Node.COMMENT_NODE || element.nodeName === 'SCRIPT' || ( element.style && element.style.display === 'none' ) ) {
+
+			return;
+
+		}
+
 		let x = 0, y = 0, width = 0, height = 0;
 
 		if ( element.nodeType === Node.TEXT_NODE ) {
@@ -264,14 +271,9 @@ function html2canvas( element ) {
 
 			drawText( style, x, y, element.nodeValue.trim() );
 
-		} else if ( element.nodeType === Node.COMMENT_NODE ) {
-
-			return;
-
 		} else if ( element instanceof HTMLCanvasElement ) {
 
 			// Canvas element
-			if ( element.style.display === 'none' ) return;
 
 			const rect = element.getBoundingClientRect();
 
@@ -286,8 +288,6 @@ function html2canvas( element ) {
 
 		} else if ( element instanceof HTMLImageElement ) {
 
-			if ( element.style.display === 'none' ) return;
-
 			const rect = element.getBoundingClientRect();
 
 			x = rect.left - offset.left - 0.5;
@@ -298,8 +298,6 @@ function html2canvas( element ) {
 			context.drawImage( element, x, y, width, height );
 
 		} else {
-
-			if ( element.style.display === 'none' ) return;
 
 			const rect = element.getBoundingClientRect();
 


### PR DESCRIPTION
Dear maintainers,

this change prevents the HTMLMesh from rendering script tags as text.

See https://github.com/mrdoob/three.js/pull/27953

All the best