### PR TITLE
Add support for input of type text and number in VR

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,8 @@
 		<a-entity hide-on-enter-ar position="0 -0.2 0" environment="lighting:none;preset:yavapai;skyType:atmosphere;">
 		</a-entity>
 		<a-torus-knot position="0 1.5 -1" radius="0.1" radius-tubular="0.02" material="shader:phong;reflectivity:0.3;" id="knot"></a-torus-knot>
+		<a-entity text="value:Hello" position="0 1.5 -1" id="textEl"></a-entity>
+		<a-entity text="" position="0 1.4 -1" id="numberEl"></a-entity>
 		<a-entity html="cursor:#cursor;html:#my-interface" shadow position="0.25 1.5 -0.5"></a-entity>
 	</a-scene>
 
@@ -125,10 +127,26 @@
 				<legend>Size:</legend>
 				<input oninput="handleRange(this)" type="range" min="0.1" max="2" value="1" step="0.01" id="myRange" style="background-color: transparent;">
 			</fieldset>
+			<fieldset style="border-radius: 1em;">
+				<legend>Text:</legend>
+				<input oninput="handleText(this)" type="text" id="myText" value="Hello">
+			</fieldset>
+			<fieldset style="border-radius: 1em;">
+				<legend>Number:</legend>
+				<input oninput="handleNumber(this)" type="number" id="myNumber">
+			</fieldset>
 			<button onclick="AFRAME.scenes[0].exitVR()" style="display: block;">Exit Immersive</button>
 		</section>
 	</div>
 	<script>
+		function handleText(detail) {
+			const text = detail.value;
+			textEl.setAttribute('text', 'value', text);
+		}
+		function handleNumber(detail) {
+			const text = detail.value;
+			numberEl.setAttribute('text', 'value', text);
+		}
 		function handleRadio(detail) {
 			const color = detail.value;
 			knot.setAttribute('material', 'color', color);

--- a/src/HTMLMesh.js
+++ b/src/HTMLMesh.js
@@ -568,6 +568,12 @@ function htmlevent( element, event, x, y ) {
 
 				}
 
+				if ( element instanceof HTMLInputElement && ( element.type === 'text' || element.type === 'number' ) && ( event === 'mousedown' || event === 'click' ) ) {
+
+					element.focus();
+
+				}
+
 			}
 
 			for ( let i = 0; i < element.childNodes.length; i ++ ) {


### PR DESCRIPTION
Add support for input of type text and number, calling `input.focus()` to bring the system keyboard in VR.
See https://latest.developers.meta.com/horizon/documentation/web/webxr-keyboard/
Note that on Meta browser 38.4 for input of type number it brings the wrong keyboard in an immersive session, while it brings the correct numeric keyboard when you're not in a immersive session. I reported it pressing 5 times the meta button.