### PR TITLE
Fixes for Safari positioning and updated three.js to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "aframe-htmlmesh",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aframe-htmlmesh",
-      "version": "2.3.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
-        "three": "^0.140.0"
+        "three": "^0.180.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.2",
@@ -803,9 +803,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.140.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.140.2.tgz",
-      "integrity": "sha512-DdT/AHm/TbZXEhQKQpGt5/iSgBrmXpjU26FNtj1KhllVPTKj1eG4X/ShyD5W2fngE+I1s1wa4ttC4C3oCJt7Ag==",
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
       "license": "MIT"
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "tablemark": "^3.0.0"
   },
   "dependencies": {
-    "three": "^0.140.0"
+    "three": "^0.180.0"
   }
 }

--- a/src/HTMLMesh.js
+++ b/src/HTMLMesh.js
@@ -310,18 +310,13 @@ function html2canvas( element ) {
 
 		} else if ( element instanceof HTMLCanvasElement ) {
 
-			// Canvas element
-
+			// Canvas element - updated for complex canvas object positioning - fixes Safari bug
 			const rect = element.getBoundingClientRect();
-
 			x = rect.left - offset.left - 0.5;
 			y = rect.top - offset.top - 0.5;
-
-		        context.save();
-			const dpr = window.devicePixelRatio;
-			context.scale( 1 / dpr, 1 / dpr );
-			context.drawImage( element, x, y );
-			context.restore();
+			const cssWidth = rect.width;
+			const cssHeight = rect.height;
+			context.drawImage( element, x, y, cssWidth, cssHeight );
 
 		} else if ( element instanceof HTMLImageElement ) {
 
@@ -537,11 +532,12 @@ function html2canvas( element ) {
 	if ( canvas === undefined ) {
 
 		canvas = document.createElement( 'canvas' );
-		canvas.width = offset.width;
-		canvas.height = offset.height;
 		canvases.set( element, canvas );
 
 	}
+
+	canvas.width = offset.width;
+	canvas.height = offset.height;
 
 	const context = canvas.getContext( '2d'/*, { alpha: false }*/ );
 


### PR DESCRIPTION
Was getting missing html to mesh components on Safari browser due to scaling issues. Worked with Chrome and others. Also brought the three.js dependency up to date to incorporate many three.js fixes.